### PR TITLE
update hc-utils method name

### DIFF
--- a/.github/nix.conf
+++ b/.github/nix.conf
@@ -1,2 +1,0 @@
-substituters = https://cache.nixos.org/ https://cache.holo.host/
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.holo.host-1:lNXIXtJgS9Iuw4Cu6X0HINLu9sTfcjEntnrgwMQIMcE= cache.holo.host-2:ZJCkX3AUYZ8soxTLfTb60g+F3MkWD7hkH9y8CgqwhDQ=

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Configure Nix substituters
-        run: |
-          set -xe
-          mkdir -p ~/.config/nix/
-          cp ./.github/nix.conf ~/.config/nix/
       - uses: cachix/cachix-action@v10
         with:
           name: holochain-ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "hc_utils"
-version = "0.0.138"
+version = "0.0.138-patch1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ff3e9e5ed3a7b06015b9713d7bf1afebcb1d96a3a60be7da0b3e545695fce7"
+checksum = "6bb0d9585eb1470fb24b3c234aa664692bf5a306a9dbaaf85794dfffb47b6593"
 dependencies = [
  "hdk",
  "holochain_deterministic_integrity",

--- a/zomes/hc_cz_profile/Cargo.toml
+++ b/zomes/hc_cz_profile/Cargo.toml
@@ -13,4 +13,4 @@ serde = "1.0.139"
 thiserror = "1.0"
 hdk = {version = "=0.0.138", feature = ["encoding"]}
 hc_iz_profile = { path = "../hc_iz_profile" }
-hc_utils = "=0.0.138"
+hc_utils = "=0.0.138-patch1"

--- a/zomes/hc_cz_profile/src/handler.rs
+++ b/zomes/hc_cz_profile/src/handler.rs
@@ -11,7 +11,7 @@ pub fn __update_my_profile(profile_input: ProfileInput) -> ProfileResult<Profile
     let agent_address = agent_info()?.agent_initial_pubkey;
     match is_registered() {
         Ok(old_data) => {
-            let old_profile_header = hc_utils::get_header(hash_entry(&old_data)?).unwrap();
+            let old_profile_header = hc_utils::get_action(hash_entry(&old_data)?).unwrap();
             let profile = Profile {
                 agent_address: agent_address.into(),
                 nickname: profile_input.nickname,


### PR DESCRIPTION
### Updates:
 - replaces hc-utils `get_header` with new `get_action` method name
 
 
**NB: Depends on [hc-utils PR #32](https://github.com/holochain/hc-utils/pull/32)**